### PR TITLE
Add support for Django 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,16 +42,8 @@ env:
     - TOXENV=py38-3.0
 matrix:
     allow_failures:
-      - env: TOXENV=py35-2.1
-      - env: TOXENV=py35-2.2
-      - env: TOXENV=py36-2.1
-      - env: TOXENV=py36-2.2
-      - env: TOXENV=py36-2.3
       - env: TOXENV=py36-3.0
-      - env: TOXENV=py37-2.1
-      - env: TOXENV=py37-2.2
       - env: TOXENV=py37-3.0
-      - env: TOXENV=py38-2.2
       - env: TOXENV=py38-3.0
 install:
     - pip install tox

--- a/markitup/widgets.py
+++ b/markitup/widgets.py
@@ -15,7 +15,7 @@ from markitup.util import absolute_url
 
 
 class MarkupInput(forms.Widget):
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         if value is not None:
             # Special handling for MarkupField value.
             # This won't touch simple TextFields because they don't have
@@ -72,7 +72,7 @@ class MarkItUpWidget(MarkupTextarea):
             js=js_media)
     media = property(_media)
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None):
         html = super(MarkItUpWidget, self).render(name, value, attrs)
 
         # Passing base_attrs as a kwarg for compatibility with Django < 1.11


### PR DESCRIPTION
These changes make the tests pass under Django 2.2, while they still
pass under Django 1.11. FWIW, they also make the wafer tests pass under
Django 2.2.