### PR TITLE
Feature/update test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ addons:
         sources:
             - deadsnakes
         packages:
-            - python3.5
-            - python3.5-dev
             - python3.6
             - python3.6-dev
             - python3.7
@@ -14,31 +12,32 @@ addons:
             - python3.8
             - python3.8-dev
             - python3.8-venv
+            - python3.9
+            - python3.9-dev
+            - python3.9-venv
 env:
-    - TOXENV=py35-1.11
-    - TOXENV=py35-2.0
-    - TOXENV=py35-2.1
-    - TOXENV=py35-2.2
-    - TOXENV=py36-1.11
-    - TOXENV=py36-2.0
-    - TOXENV=py36-2.1
     - TOXENV=py36-2.2
     - TOXENV=py36-3.0
+    - TOXENV=py36-3.1
     - TOXENV=py36-djdev
-    - TOXENV=py37-1.11
-    - TOXENV=py37-2.0
-    - TOXENV=py37-2.1
     - TOXENV=py37-2.2
     - TOXENV=py37-3.0
+    - TOXENV=py37-3.1
     - TOXENV=py37-djdev
     - TOXENV=py38-2.2
     - TOXENV=py38-3.0
+    - TOXENV=py38-3.1
     - TOXENV=py38-djdev
+    - TOXENV=py39-2.2
+    - TOXENV=py39-3.0
+    - TOXENV=py39-3.1
+    - TOXENV=py39-djdev
 matrix:
     allow_failures:
         - env: TOXENV=py36-djdev
         - env: TOXENV=py37-djdev
         - env: TOXENV=py38-djdev
+        - env: TOXENV=py39-djdev
 install:
     - pip install tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
         - env: TOXENV=py38-djdev
         - env: TOXENV=py39-djdev
 install:
-    - pip install virtualenv
+    - pip install -U virtualenv
     - pip install tox
 script:
     - export PYTHONPATH=$PYTHONPATH:`pwd`

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ matrix:
         - env: TOXENV=py38-djdev
         - env: TOXENV=py39-djdev
 install:
+    - pip install virtualenv
     - pip install tox
 script:
     - export PYTHONPATH=$PYTHONPATH:`pwd`

--- a/tox.ini
+++ b/tox.ini
@@ -1,30 +1,27 @@
 [tox]
 envlist=
-  py35-1.11
-  py35-2.{0,1,2}
-  py36-1.11
-  py36-2.{0,1,2}
-  py36-3.0
+  py36-2.2
+  py36-3.{0,1}
   py36-djdev
-  py37-1.11
-  py37-2.{0,1,2}
-  py37-3.0
+  py37-2.2
+  py37-3.{0,1}
   py37-djdev
   py38-2.2
-  py38-3.0
+  py38-3.{0,1}
   py38-djdev
+  py39-2.2
+  py39-3.{0,1}
+  py39-djdev
 
 [testenv]
 basepython =
-  py35: python3.5
   py36: python3.6
   py37: python3.7
   py38: python3.8
+  py39: python3.9
 commands=python setup.py test
 deps =
-  1.11: Django>=1.11,<2
-  2.0: Django>=2.0,<2.1
-  2.1: Django>=2.1,<2.2
   2.2: Django>=2.2,<3
   3.0: Django>=3.0,<3.1
+  3.1: Django>=3.1,<3.2
   djdev: https://github.com/django/django/archive/master.tar.gz


### PR DESCRIPTION
This updates the test matrix to the current version of Django and adds Python 3.9 support

We fix some issues with the tests on Django 3.1 as well (no actual code changes needed).