### PR TITLE
markdown's safe_mode is gone

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -326,7 +326,7 @@ to the filter function.  The dictionary may be empty.
 For example, if you have python-markdown installed, you could use it
 like this::
 
-    MARKITUP_FILTER = ('markdown.markdown', {'safe_mode': True})
+    MARKITUP_FILTER = ('markdown.markdown', {})
 
 Alternatively, you could use the "textile" filter provided by the
 django-markwhat library like this::

--- a/README.rst
+++ b/README.rst
@@ -339,6 +339,31 @@ kwargs dictionary must be empty in this case.)
 ``django-markitup`` provides one sample rendering function,
 ``render_rest`` in the ``markitup.renderers`` module.
 
+Avoiding Cross Site Scripting (XSS) attacks
+-------------------------------------------
+
+If your site is displaying user-provided markup to the world, then there
+is some risk of users injecting malicious ``<script>`` tags (or similar)
+into their markup text, that your site will then render in its HTML
+pages. Any filter that passes through HTML unmodified (e.g.
+python-markdown) is especially at-risk, here.
+
+This can be mitigated by running the rendered HTML through the bleach
+library, e.g::
+
+    MARKITUP_FILTER = ('my_lib.bleached_markdown', {})
+
+Where ``my_lib`` contains::
+
+    import bleach
+    from bleach_allowlist import markdown_tags, markdown_attrs
+    from markdown import markdown
+
+    def bleached_markdown(text, **kwargs):
+        markdown_rendered = markdown(text, **kwargs)
+        bleached = bleach.clean(markdown_rendered, markdown_tags, markdown_attrs)
+        return bleached
+
 render_markup template filter
 =============================
 

--- a/markitup/markup.py
+++ b/markitup/markup.py
@@ -13,12 +13,12 @@ along with the markup to parse.
 
 For instance, if MARKITUP_PREVIEW_FILTER is set to::
 
-    ('markdown.markdown', {'safe_mode': True})
+    ('markdown.markdown', {'output_format': 'html5'})
 
 then calling ``filter_func(text)`` is equivalent to::
 
     from markdown import markdown
-    markdown(text, safe_mode=True)
+    markdown(text, output_format='html5')
 
 Though the implementation differs, the format of the
 MARKITUP_PREVIEW_FILTER setting is inspired by James Bennett's

--- a/tests/project/settings.py
+++ b/tests/project/settings.py
@@ -30,7 +30,7 @@ TEMPLATES = [
 
 ROOT_URLCONF = 'tests.project.urls'
 
-MARKITUP_FILTER = ('markdown.markdown', {'safe_mode': True})
+MARKITUP_FILTER = ('markdown.markdown', {})
 MARKITUP_SET = 'markitup/sets/markdown/'  # Default includes trailing slash so that others know it's a directory
 
 DEBUG = True


### PR DESCRIPTION
Remove mentions of it from docs, and add a section on how to implement your own replacement, with bleach